### PR TITLE
[#8] 로그인 기능 테스트코드 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,7 @@ repositories {
 dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
     implementation 'com.auth0:java-jwt:4.4.0'
+    implementation 'com.github.javafaker:javafaker:1.0.2'
     implementation 'com.h2database:h2:2.1.214'
     implementation 'commons-codec:commons-codec:1.15'
     implementation 'org.mapstruct:mapstruct:1.5.3.Final'

--- a/app/src/test/java/com/hotelJava/member/MemberTestFixture.java
+++ b/app/src/test/java/com/hotelJava/member/MemberTestFixture.java
@@ -1,25 +1,33 @@
 package com.hotelJava.member;
 
+import com.github.javafaker.Faker;
+import com.hotelJava.member.domain.Grade;
 import com.hotelJava.member.domain.Member;
+import com.hotelJava.member.domain.Role;
 import com.hotelJava.member.dto.SignUpRequestDto;
 
 public class MemberTestFixture {
+
+  private static final Faker faker = Faker.instance();
+
   /** test fixture */
-  public static SignUpRequestDto getTestSignUpDto() {
+  public static SignUpRequestDto getSignUpDto() {
     return SignUpRequestDto.builder()
-        .email("testcode@example.com")
-        .name("testcode")
-        .phone("010-1111-2222")
-        .password("abcd1234")
+        .email(faker.internet().emailAddress())
+        .password(faker.internet().password())
+        .name(faker.name().name())
+        .phone(faker.phoneNumber().phoneNumber())
         .build();
   }
 
-  public static Member getTestMember() {
+  public static Member getMember() {
     return Member.builder()
-        .email("testcode@emxample.com")
-        .name("010-1111-2222")
-        .phone("010-1111-2222")
-        .password("abcd1234")
+        .email(faker.internet().emailAddress())
+        .password(faker.internet().password())
+        .name(faker.name().name())
+        .phone(faker.phoneNumber().phoneNumber())
+        .role(faker.options().option(Role.values()))
+        .grade(faker.options().option(Grade.values()))
         .build();
   }
 }

--- a/app/src/test/java/com/hotelJava/member/service/MemberServiceTest.java
+++ b/app/src/test/java/com/hotelJava/member/service/MemberServiceTest.java
@@ -1,15 +1,14 @@
 package com.hotelJava.member.service;
 
-import static com.hotelJava.member.MemberTestFixture.getTestMember;
-import static com.hotelJava.member.MemberTestFixture.getTestSignUpDto;
-import static com.hotelJava.member.util.MemberMapper.MEMBER_MAPPER;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.hotelJava.member.MemberTestFixture.getMember;
+import static com.hotelJava.member.MemberTestFixture.getSignUpDto;
 
 import com.hotelJava.member.domain.Member;
 import com.hotelJava.member.dto.SignUpRequestDto;
 import com.hotelJava.member.repository.MemberRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,21 +27,26 @@ class MemberServiceTest {
   @DisplayName("회원가입 기능을 테스트한다.")
   void signUp() {
     // given
-    SignUpRequestDto signUpDto = getTestSignUpDto();
+    SignUpRequestDto signUpDto = getSignUpDto();
 
     // when
     memberService.signUp(signUpDto);
     Member findMember = memberRepository.findByEmail(signUpDto.getEmail()).orElse(null);
 
     // then
-    assertThat(MEMBER_MAPPER.toSignUpRequestDto(findMember)).isEqualTo(signUpDto);
+    SoftAssertions.assertSoftly(
+        softly -> {
+          softly.assertThat(findMember.getEmail()).isEqualTo(signUpDto.getEmail());
+          softly.assertThat(findMember.getName()).isEqualTo(signUpDto.getName());
+          softly.assertThat(findMember.getPhone()).isEqualTo(signUpDto.getPhone());
+        });
   }
 
   @Test
   @DisplayName("이메일 중복 검사 기능을 테스트한다.")
   void isDuplicated() {
     // given
-    Member member = getTestMember();
+    Member member = getMember();
     memberRepository.save(member);
 
     // when

--- a/app/src/test/java/com/hotelJava/security/MemberDetailsServiceTest.java
+++ b/app/src/test/java/com/hotelJava/security/MemberDetailsServiceTest.java
@@ -1,11 +1,12 @@
 package com.hotelJava.security;
 
-import static com.hotelJava.member.MemberTestFixture.getTestMember;
+import static com.hotelJava.member.MemberTestFixture.getMember;
 import static com.hotelJava.security.MemberDetails.parseAuthorities;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.github.javafaker.Faker;
 import com.hotelJava.common.error.ErrorCode;
 import com.hotelJava.common.error.exception.BadRequestException;
 import com.hotelJava.common.error.exception.CommonException;
@@ -30,7 +31,7 @@ class MemberDetailsServiceTest {
   @DisplayName("이메일을 바탕으로 사용자를 올바르게 인식하는지 테스트한다")
   void loadUserByUsername_MemberDetails_ValidMember() {
     // given
-    Member member = getTestMember();
+    Member member = getMember();
     memberRepository.save(member);
 
     // when
@@ -52,7 +53,7 @@ class MemberDetailsServiceTest {
   @DisplayName("등록되지 않은 이메일로 사용자를 조회하면 예외가 발생하는지 테스트한다")
   void loadUserByUsername_BadRequestException_NonExistMember() {
     // given
-    String email = "example@test.com";
+    String email = Faker.instance().internet().emailAddress();
 
     // when, then
     CommonException exception =

--- a/app/src/test/java/com/hotelJava/security/MemberDetailsTest.java
+++ b/app/src/test/java/com/hotelJava/security/MemberDetailsTest.java
@@ -1,0 +1,28 @@
+package com.hotelJava.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.javafaker.Faker;
+import com.hotelJava.member.domain.Role;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+class MemberDetailsTest {
+
+  private final Faker faker = Faker.instance();
+
+  @Test
+  @DisplayName("Role 이 주어지면 List<SimpleGrantedAuthority> 가 반환된다")
+  void parseAuthorities_list() {
+    // given
+    Role role = faker.options().option(Role.class);
+
+    // when
+    List<SimpleGrantedAuthority> authorities = MemberDetails.parseAuthorities(role);
+
+    // then
+    assertThat(authorities).isEqualTo(List.of(new SimpleGrantedAuthority(role.name())));
+  }
+}

--- a/app/src/test/java/com/hotelJava/security/filter/FilterSkipMatcherTest.java
+++ b/app/src/test/java/com/hotelJava/security/filter/FilterSkipMatcherTest.java
@@ -1,0 +1,48 @@
+package com.hotelJava.security.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.javafaker.Faker;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+class FilterSkipMatcherTest {
+
+  private final Faker faker = new Faker();
+
+  @Test
+  @DisplayName("skip 경로가 아니고 default 경로인 요청이 매개변수로 주어진다면 결과는 true 이다")
+  void matches_true() {
+    // given
+    String defaultPath = faker.letterify("/?????");
+    String skipPath = faker.letterify("/?????");
+
+    // when
+    FilterSkipMatcher matcher =
+        new FilterSkipMatcher(defaultPath, AntPathRequestMatcher.antMatcher(skipPath));
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setServletPath(defaultPath);
+
+    // then
+    assertThat(matcher.matches(request)).isTrue();
+  }
+
+  @Test
+  @DisplayName("skip 경로인 요청이 매개변수로 주어진다면 결과는 false 이다")
+  void matches_false() {
+    // given
+    String defaultPath = faker.letterify("/?????");
+    String skipPath = faker.letterify("/?????");
+
+    // when
+    FilterSkipMatcher matcher =
+            new FilterSkipMatcher(defaultPath, AntPathRequestMatcher.antMatcher(skipPath));
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setServletPath(skipPath);
+
+    // then
+    assertThat(matcher.matches(request)).isFalse();
+  }
+}

--- a/app/src/test/java/com/hotelJava/security/filter/JwtAuthenticationFilterTest.java
+++ b/app/src/test/java/com/hotelJava/security/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,61 @@
+package com.hotelJava.security.filter;
+
+import com.hotelJava.common.error.exception.BadRequestException;
+import com.hotelJava.member.MemberTestFixture;
+import com.hotelJava.member.domain.Member;
+import com.hotelJava.security.token.JwtPostAuthenticationToken;
+import com.hotelJava.security.util.impl.JwtPayload;
+import com.hotelJava.security.util.impl.JwtTokenFactory;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+
+@SpringBootTest
+class JwtAuthenticationFilterTest {
+
+  @Autowired private JwtAuthenticationFilter jwtFilter;
+  @Autowired private JwtTokenFactory jwtTokenFactory;
+
+  @Test
+  @DisplayName("인증에 성공한다면 JwtPostAuthenticationToken 객체가 반환된다")
+  void attemptAuthentication_Authentication_success() {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    String token = getJwtToken(MemberTestFixture.getMember(), System.currentTimeMillis());
+    request.addHeader("Authorization", token);
+
+    // when
+    Authentication authentication = jwtFilter.attemptAuthentication(request, response);
+
+    // then
+    Assertions.assertThat(authentication).isInstanceOf(JwtPostAuthenticationToken.class);
+  }
+
+  @Test
+  @DisplayName("인증에 실패한다면 BadRequestException 예외가 발생한다")
+  void attemptAuthentication_Exception_failed() {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    // when
+    Assertions.assertThatThrownBy(() -> jwtFilter.attemptAuthentication(request, response))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  private String getJwtToken(Member member, long currentTime) {
+    JwtPayload payload =
+        JwtPayload.builder()
+            .subject(member.getEmail())
+            .roles(List.of(member.getRole().name()))
+            .build();
+    return jwtTokenFactory.generate(payload, currentTime);
+  }
+}

--- a/app/src/test/java/com/hotelJava/security/filter/LoginAuthenticationFilterTest.java
+++ b/app/src/test/java/com/hotelJava/security/filter/LoginAuthenticationFilterTest.java
@@ -1,0 +1,65 @@
+package com.hotelJava.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.javafaker.Faker;
+import com.hotelJava.common.error.exception.BadRequestException;
+import com.hotelJava.member.MemberTestFixture;
+import com.hotelJava.member.dto.SignUpRequestDto;
+import com.hotelJava.member.service.MemberService;
+import com.hotelJava.security.dto.LoginDto;
+import com.hotelJava.security.token.LoginPostAuthenticationToken;
+import java.io.IOException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+
+@SpringBootTest
+class LoginAuthenticationFilterTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  @Autowired private LoginAuthenticationFilter loginFilter;
+  @Autowired private MemberService memberService;
+
+  @Test
+  @DisplayName("인증에 성공한다면 Authentication 객체가 리턴된다")
+  void attemptAuthentication_Authentication_success() throws IOException {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    SignUpRequestDto signUpDto = MemberTestFixture.getSignUpDto();
+    memberService.signUp(signUpDto);
+
+    // when
+    LoginDto dto = new LoginDto(signUpDto.getEmail(), signUpDto.getPassword());
+    request.setContent(objectMapper.writeValueAsBytes(dto));
+    Authentication authentication = loginFilter.attemptAuthentication(request, response);
+
+    // then
+    Assertions.assertThat(authentication).isInstanceOf(LoginPostAuthenticationToken.class);
+  }
+
+  @Test
+  @DisplayName("인증에 실패한다면 BadRequestException 예외가 발생한다")
+  void attemptAuthentication_Exception_failed() throws IOException {
+    // given
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    String email = Faker.instance().internet().emailAddress();
+    String password = Faker.instance().internet().password();
+
+    // when
+    LoginDto dto = new LoginDto(email, password);
+    request.setContent(objectMapper.writeValueAsBytes(dto));
+
+    // then
+    Assertions.assertThatThrownBy(() -> loginFilter.attemptAuthentication(request, response))
+        .isInstanceOf(BadRequestException.class);
+  }
+}

--- a/app/src/test/java/com/hotelJava/security/handler/LoginAuthenticationSuccessHandlerTest.java
+++ b/app/src/test/java/com/hotelJava/security/handler/LoginAuthenticationSuccessHandlerTest.java
@@ -1,0 +1,38 @@
+package com.hotelJava.security.handler;
+
+import com.hotelJava.member.MemberTestFixture;
+import com.hotelJava.member.domain.Member;
+import com.hotelJava.security.MemberDetails;
+import com.hotelJava.security.token.LoginPostAuthenticationToken;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+
+@SpringBootTest
+class LoginAuthenticationSuccessHandlerTest {
+
+  @Autowired private LoginAuthenticationSuccessHandler successHandler;
+
+  @Test
+  @DisplayName("로그인에 성공하면 응답 메시지의 Authorization 헤더에 토큰값을 남긴다")
+  void onAuthenticationSuccess() {
+    // given
+    Member member = MemberTestFixture.getMember();
+    MemberDetails memberDetails = new MemberDetails(member);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    Authentication authentication = new LoginPostAuthenticationToken(memberDetails);
+
+    // when
+    successHandler.onAuthenticationSuccess(request, response, authentication);
+
+    // then
+    Assertions.assertThat(response.getHeader("Authorization")).isNotNull();
+  }
+}

--- a/app/src/test/java/com/hotelJava/security/token/LoginPostAuthenticationTokenTest.java
+++ b/app/src/test/java/com/hotelJava/security/token/LoginPostAuthenticationTokenTest.java
@@ -1,0 +1,33 @@
+package com.hotelJava.security.token;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.hotelJava.member.MemberTestFixture;
+import com.hotelJava.security.MemberDetails;
+import com.hotelJava.security.util.impl.JwtPayload;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LoginPostAuthenticationTokenTest {
+
+  @Test
+  @DisplayName("로그인 인증을 통과한 토큰으로부터 JWT 페이로드를 추출할 수 있다")
+  void getJwtPayload_JwtPayload() {
+
+    // given
+    MemberDetails memberDetails = new MemberDetails(MemberTestFixture.getMember());
+    LoginPostAuthenticationToken postAuthToken = new LoginPostAuthenticationToken(memberDetails);
+
+    // when
+    JwtPayload jwtPayload = postAuthToken.getJwtPayload();
+
+    // then
+    JwtPayload expect =
+        JwtPayload.builder()
+            .subject(postAuthToken.getEmail())
+            .roles(postAuthToken.getRoles())
+            .build();
+
+    assertThat(jwtPayload).isEqualTo(expect);
+  }
+}

--- a/app/src/test/java/com/hotelJava/security/util/specification/JwtTokenDecoderTest.java
+++ b/app/src/test/java/com/hotelJava/security/util/specification/JwtTokenDecoderTest.java
@@ -1,0 +1,57 @@
+package com.hotelJava.security.util.specification;
+
+import com.hotelJava.common.error.exception.BadRequestException;
+import com.hotelJava.member.MemberTestFixture;
+import com.hotelJava.member.domain.Member;
+import com.hotelJava.security.MemberDetails;
+import com.hotelJava.security.util.impl.JwtPayload;
+import com.hotelJava.security.util.impl.JwtTokenDecoder;
+import com.hotelJava.security.util.impl.JwtTokenFactory;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class JwtTokenDecoderTest {
+
+  @Autowired private JwtTokenDecoder jwtTokenDecoder;
+  @Autowired private JwtTokenFactory jwtTokenFactory;
+
+  @Test
+  @DisplayName("유효한 토큰은 디코딩했을 때 MemberDetails 정보를 가져올 수 있다")
+  void verify_DecodedJWT() {
+    // given
+    Member member = MemberTestFixture.getMember();
+    String token = getJwtToken(member, System.currentTimeMillis());
+
+    // when
+    MemberDetails memberDetails = jwtTokenDecoder.decode(token);
+
+    // then
+    Assertions.assertThat(new MemberDetails(member)).isEqualTo(memberDetails);
+  }
+
+  @Test
+  @DisplayName("유효 시간이 지난 토큰은 디코딩했을 때 예외가 발생한다")
+  void verify_Exception() {
+    // given
+    Member member = MemberTestFixture.getMember();
+    String token = getJwtToken(member, 1000);
+
+    // when, then
+    Assertions.assertThatThrownBy(() -> jwtTokenDecoder.decode(token))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  private String getJwtToken(Member member, long currentTime) {
+    JwtPayload payload =
+        JwtPayload.builder()
+            .subject(member.getEmail())
+            .roles(List.of(member.getRole().name()))
+            .build();
+    return jwtTokenFactory.generate(payload, currentTime);
+  }
+}

--- a/restapi/Member.http
+++ b/restapi/Member.http
@@ -1,0 +1,24 @@
+###
+GET http://localhost:8080/api/members
+Authorization: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZXMiOlsiVVNFUiJdLCJleHAiOjE2ODE2NzAxMTgsImlzcyI6IkhvdGVsLWphdmEifQ.55Pi4jErRNVH_DQKgNloXr9GSjLNIvdsFpRMQuy6KtS63Guzd_Zy3O5oiH-v-DQuWdkhbqRBCFAmBSouc2xz6w
+
+###
+POST http://localhost:8080/api/members
+Content-Type: application/json
+
+{
+  "email": "test@test.com",
+  "name": "kim",
+  "password": "1234",
+  "phone": "010-1111-2222"
+}
+
+###
+GET http://localhost:8080/login
+Content-Type: application/json
+
+{
+    "email": "test@test.com",
+    "password": "1234"
+}
+


### PR DESCRIPTION
# ❓궁금한 점
`JwtAuthenticationFilter`의 로직을 살펴보면 `JwtAuthenticationProvider`에게 인증 작업을 위임하는데요. 

`JwtAuthenticationFilter`만 테스트해도 `JwtAuthenticationProvider`가 올바르게 동작하는지 검증된다는 생각이 들었습니다. JwtAuthenticationProvider 테스트코드를 별도로 작성해야되나요?