### PR TITLE
[#8] 로그인 기능 Bearer 토큰 인증방식으로 변경

### DIFF
--- a/app/src/main/java/com/hotelJava/common/error/ErrorCode.java
+++ b/app/src/main/java/com/hotelJava/common/error/ErrorCode.java
@@ -23,7 +23,10 @@ public enum ErrorCode {
   // 숙소 관련 에러
   ACCOMMODATION_NOT_FOUND(404, "해당 숙소가 존재하지 않습니다."),
   DUPLICATED_NAME_FOUND(409, "숙소명이 이미 존재합니다."),
-  NO_MINIMUM_PRICE_FOUND(500, "숙소의 최소 가격을 찾을 수 없습니다.");
+  NO_MINIMUM_PRICE_FOUND(500, "숙소의 최소 가격을 찾을 수 없습니다."),
+
+  // 서버 에러
+  INTERNAL_SERVER_ERROR(500, "요청을 정상 처리하지 못하였습니다.");
 
   private final int code;
   private final String message;

--- a/app/src/main/java/com/hotelJava/security/config/SecurityConfig.java
+++ b/app/src/main/java/com/hotelJava/security/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import com.hotelJava.security.filter.LoginAuthenticationFilter;
 import com.hotelJava.security.handler.LoginAuthenticationSuccessHandler;
 import com.hotelJava.security.provider.JwtAuthenticationProvider;
 import com.hotelJava.security.provider.MemberDetailsAuthenticationProvider;
+import com.hotelJava.security.util.impl.HeaderTokenExtractor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -40,6 +41,7 @@ public class SecurityConfig {
   private final AccessDeniedHandler accessDeniedHandler;
   private final AuthenticationEntryPoint authenticationEntryPoint;
   private final ExceptionHandlerFilter exceptionHandlerFilter;
+  private final HeaderTokenExtractor extractor;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager manager)
@@ -100,7 +102,7 @@ public class SecurityConfig {
     FilterSkipMatcher matcher =
         new FilterSkipMatcher(
             API_URL, antMatcher(LOGIN_URL), antMatcher(HttpMethod.POST, SIGNUP_URL));
-    JwtAuthenticationFilter filter = new JwtAuthenticationFilter(matcher);
+    JwtAuthenticationFilter filter = new JwtAuthenticationFilter(matcher, extractor);
     filter.setAuthenticationManager(authenticationManager);
     return filter;
   }

--- a/app/src/main/java/com/hotelJava/security/dto/TokenDto.java
+++ b/app/src/main/java/com/hotelJava/security/dto/TokenDto.java
@@ -1,0 +1,4 @@
+package com.hotelJava.security.dto;
+
+
+public record TokenDto(String token) {}

--- a/app/src/main/java/com/hotelJava/security/filter/JwtAuthenticationFilter.java
+++ b/app/src/main/java/com/hotelJava/security/filter/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.hotelJava.security.filter;
 import com.hotelJava.common.error.ErrorCode;
 import com.hotelJava.common.error.exception.BadRequestException;
 import com.hotelJava.security.token.JwtPreAuthenticationToken;
+import com.hotelJava.security.util.impl.HeaderTokenExtractor;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,15 +20,18 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 @Slf4j
 public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
 
-  public JwtAuthenticationFilter(RequestMatcher requestMatcher) {
+  private final HeaderTokenExtractor extractor;
+
+  public JwtAuthenticationFilter(RequestMatcher requestMatcher, HeaderTokenExtractor extractor) {
     super(requestMatcher);
+    this.extractor = extractor;
   }
 
   @Override
   public Authentication attemptAuthentication(
       HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
     log.trace("jwt login request received");
-    String jwtToken = request.getHeader("Authorization");
+    String jwtToken = extractor.extract(request.getHeader("Authorization"));
 
     if (jwtToken == null) {
       log.error("authorization is null");

--- a/app/src/main/java/com/hotelJava/security/handler/LoginAuthenticationSuccessHandler.java
+++ b/app/src/main/java/com/hotelJava/security/handler/LoginAuthenticationSuccessHandler.java
@@ -1,9 +1,14 @@
 package com.hotelJava.security.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hotelJava.common.error.ErrorCode;
+import com.hotelJava.common.error.exception.InternalServerException;
+import com.hotelJava.security.dto.TokenDto;
 import com.hotelJava.security.token.LoginPostAuthenticationToken;
 import com.hotelJava.security.util.impl.JwtTokenFactory;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -25,6 +30,17 @@ public class LoginAuthenticationSuccessHandler extends SimpleUrlAuthenticationSu
     String token =
         jwtTokenFactory.generate(postAuthToken.getJwtPayload(), System.currentTimeMillis());
 
-    response.setHeader("Authorization", token);
+    writeResponse(response, token);
+  }
+
+  private void writeResponse(HttpServletResponse response, String token) {
+    ObjectMapper objectMapper = new ObjectMapper();
+    TokenDto dto = new TokenDto(token);
+    try {
+      response.getWriter().write(objectMapper.writeValueAsString(dto));
+    } catch (IOException e) {
+      log.error("problem with writing jwt token");
+      throw new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
   }
 }

--- a/app/src/main/java/com/hotelJava/security/util/impl/HeaderTokenExtractor.java
+++ b/app/src/main/java/com/hotelJava/security/util/impl/HeaderTokenExtractor.java
@@ -1,0 +1,20 @@
+package com.hotelJava.security.util.impl;
+
+import com.hotelJava.common.error.ErrorCode;
+import com.hotelJava.common.error.exception.BadRequestException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class HeaderTokenExtractor {
+  public static final String TOKEN_PREFIX = "Bearer ";
+
+  public String extract(String header) {
+    if (header == null || header.length() < TOKEN_PREFIX.length()) {
+      log.error("token extract fail");
+      throw new BadRequestException(ErrorCode.AUTHENTICATION_FAIL);
+    }
+    return header.substring(TOKEN_PREFIX.length());
+  }
+}

--- a/app/src/test/java/com/hotelJava/security/util/impl/HeaderTokenExtractorTest.java
+++ b/app/src/test/java/com/hotelJava/security/util/impl/HeaderTokenExtractorTest.java
@@ -1,0 +1,23 @@
+package com.hotelJava.security.util.impl;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.github.javafaker.Faker;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class HeaderTokenExtractorTest {
+
+  private final HeaderTokenExtractor extractor = new HeaderTokenExtractor();
+
+  @Test
+  @DisplayName("Authorization Header 에서 토큰값만 추출한다")
+  void extract_tokenValue() {
+    // given
+    String token = Faker.instance().letterify("????????");
+    String header = HeaderTokenExtractor.TOKEN_PREFIX + token;
+    
+    // when, then
+    assertThat(extractor.extract(header)).isEqualTo(token);
+  }
+}

--- a/restapi/Member.http
+++ b/restapi/Member.http
@@ -1,6 +1,6 @@
 ###
 GET http://localhost:8080/api/members
-Authorization: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZXMiOlsiVVNFUiJdLCJleHAiOjE2ODE2NzAxMTgsImlzcyI6IkhvdGVsLWphdmEifQ.55Pi4jErRNVH_DQKgNloXr9GSjLNIvdsFpRMQuy6KtS63Guzd_Zy3O5oiH-v-DQuWdkhbqRBCFAmBSouc2xz6w
+Authorization: Bearer token-value
 
 ###
 POST http://localhost:8080/api/members


### PR DESCRIPTION
# 🎯 주요 작업 내용
## 클라이언트에게 토큰값 전달하는 방법 변경
- Before: 클라이언트가 로그인 요청을 해왔을 때, 인증을 통과하면 Response의 Authorization 헤더에 토큰값을 담아주었습니다.
- To-Be: 토큰값을 Response Body에 담아주도록 변경하였습니다.

## Bearer 토큰 인증 방식 적용
토큰값을 이미 들고있는 클라이언트가 서버로 요청을 할 때, `Bear token-value` 형태로 Authorization 필드로 토큰을 전달할 것이라고 가정했습니다. 가정을 토대로 JwtAuthenticationFilter 를 수정하였습니다.