### PR TITLE
[#22] 개인정보 수정기능 추가

### DIFF
--- a/app/src/main/java/com/hotelJava/member/controller/MemberController.java
+++ b/app/src/main/java/com/hotelJava/member/controller/MemberController.java
@@ -1,10 +1,13 @@
 package com.hotelJava.member.controller;
 
+import com.hotelJava.member.dto.ChangeProfileRequestDto;
 import com.hotelJava.member.dto.SignUpRequestDto;
 import com.hotelJava.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,7 +21,14 @@ public class MemberController {
   private final MemberService memberService;
 
   @PostMapping
-  public void signUp(@RequestBody SignUpRequestDto signUpDto) {
-    memberService.signUp(signUpDto);
+  public void signUp(@RequestBody SignUpRequestDto dto) {
+    memberService.signUp(dto);
+  }
+
+  @PutMapping
+  public void changeProfile(
+      @AuthenticationPrincipal(expression = "email") String loginEmail,
+      ChangeProfileRequestDto dto) {
+    memberService.changeProfile(loginEmail, dto);
   }
 }

--- a/app/src/main/java/com/hotelJava/member/domain/Member.java
+++ b/app/src/main/java/com/hotelJava/member/domain/Member.java
@@ -11,7 +11,9 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Builder.Default;
-import lombok.EqualsAndHashCode;import lombok.Getter;import lombok.NoArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,7 +21,7 @@ import lombok.EqualsAndHashCode;import lombok.Getter;import lombok.NoArgsConstru
 @Getter
 @Builder
 @Entity
-public class Member implements ProfileInfo {
+public class Member implements Profile {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,5 +49,10 @@ public class Member implements ProfileInfo {
 
   public void changePassword(String password) {
     this.password = password;
+  }
+
+  public void changeProfile(Profile profileInfo) {
+    this.name = profileInfo.getName();
+    this.phone = profileInfo.getPhone();
   }
 }

--- a/app/src/main/java/com/hotelJava/member/domain/Profile.java
+++ b/app/src/main/java/com/hotelJava/member/domain/Profile.java
@@ -1,0 +1,7 @@
+package com.hotelJava.member.domain;
+
+public interface Profile {
+  String getName();
+
+  String getPhone();
+}

--- a/app/src/main/java/com/hotelJava/member/dto/ChangeProfileRequestDto.java
+++ b/app/src/main/java/com/hotelJava/member/dto/ChangeProfileRequestDto.java
@@ -1,0 +1,12 @@
+package com.hotelJava.member.dto;
+
+import com.hotelJava.member.domain.Profile;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChangeProfileRequestDto implements Profile {
+  private String name;
+  private String phone;
+}

--- a/app/src/main/java/com/hotelJava/member/service/MemberService.java
+++ b/app/src/main/java/com/hotelJava/member/service/MemberService.java
@@ -5,12 +5,14 @@ import static com.hotelJava.member.util.MemberMapper.MEMBER_MAPPER;
 import com.hotelJava.common.error.ErrorCode;
 import com.hotelJava.common.error.exception.BadRequestException;
 import com.hotelJava.member.domain.Member;
+import com.hotelJava.member.dto.ChangeProfileRequestDto;
 import com.hotelJava.member.dto.SignUpRequestDto;
 import com.hotelJava.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -20,6 +22,7 @@ public class MemberService {
   private final MemberRepository memberRepository;
   private final PasswordEncoder passwordEncoder;
 
+  @Transactional
   public void signUp(SignUpRequestDto dto) {
     if (isDuplicatedEmail(dto.getEmail())) {
       throw new BadRequestException(ErrorCode.DUPLICATED_EMAIL_FOUND);
@@ -29,8 +32,20 @@ public class MemberService {
     memberRepository.save(member);
   }
 
+  @Transactional
+  public void changeProfile(String email, ChangeProfileRequestDto dto) {
+    Member member = findByEmail(email);
+    member.changeProfile(dto);
+  }
+
   public boolean isDuplicatedEmail(String email) {
     return memberRepository.existsByEmail(email);
+  }
+
+  private Member findByEmail(String email) {
+    return memberRepository
+        .findByEmail(email)
+        .orElseThrow(() -> new BadRequestException(ErrorCode.EMAIL_NOT_FOUND));
   }
 
   private String encrypt(String password) {

--- a/app/src/main/java/com/hotelJava/security/token/JwtPostAuthenticationToken.java
+++ b/app/src/main/java/com/hotelJava/security/token/JwtPostAuthenticationToken.java
@@ -5,6 +5,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 
 public class JwtPostAuthenticationToken extends UsernamePasswordAuthenticationToken {
   public JwtPostAuthenticationToken(MemberDetails memberDetails) {
-    super(memberDetails.getEmail(), memberDetails.getPassword(), memberDetails.getAuthorities());
+    super(memberDetails, memberDetails.getPassword(), memberDetails.getAuthorities());
   }
 }

--- a/app/src/test/java/com/hotelJava/member/MemberTestFixture.java
+++ b/app/src/test/java/com/hotelJava/member/MemberTestFixture.java
@@ -4,6 +4,7 @@ import com.github.javafaker.Faker;
 import com.hotelJava.member.domain.Grade;
 import com.hotelJava.member.domain.Member;
 import com.hotelJava.member.domain.Role;
+import com.hotelJava.member.dto.ChangeProfileRequestDto;
 import com.hotelJava.member.dto.SignUpRequestDto;
 
 public class MemberTestFixture {
@@ -15,6 +16,13 @@ public class MemberTestFixture {
     return SignUpRequestDto.builder()
         .email(faker.internet().emailAddress())
         .password(faker.internet().password())
+        .name(faker.name().name())
+        .phone(faker.phoneNumber().phoneNumber())
+        .build();
+  }
+
+  public static ChangeProfileRequestDto getChangeProfileDto() {
+    return ChangeProfileRequestDto.builder()
         .name(faker.name().name())
         .phone(faker.phoneNumber().phoneNumber())
         .build();


### PR DESCRIPTION
## 🎯  주요 작업
1. 개인정보 수정 기능 추가
- 로그인 정보를 @AuthenticationPrincipal 애노테이션을 활용하여 MemberController에게 전달
- Member 도메인 changeProfile() 메서드 구현

3. 개인정보 수정 기능 테스트코드 추가
- 개인정보가 이미 가입된 given 상황을 가정하기 위해 Mockito @SpyBean 활용