### PR TITLE
hotfix: 시큐리티 버그 수정

### DIFF
--- a/app/src/main/java/com/hotelJava/member/dto/SignUpRequestDto.java
+++ b/app/src/main/java/com/hotelJava/member/dto/SignUpRequestDto.java
@@ -1,6 +1,6 @@
 package com.hotelJava.member.dto;
 
-import com.hotelJava.member.domain.ProfileInfo;
+import com.hotelJava.member.domain.Profile;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class SignUpRequestDto implements ProfileInfo {
+public class SignUpRequestDto implements Profile {
   private String email;
   private String name;
   private String password;

--- a/app/src/main/java/com/hotelJava/security/MemberDetails.java
+++ b/app/src/main/java/com/hotelJava/security/MemberDetails.java
@@ -2,6 +2,7 @@ package com.hotelJava.security;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 import com.hotelJava.member.domain.Member;
 import com.hotelJava.member.domain.Role;
 import org.springframework.security.core.GrantedAuthority;
@@ -9,6 +10,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 
 public class MemberDetails extends User {
+
   public MemberDetails(
       String email, String password, Collection<? extends GrantedAuthority> authorities) {
     super(email, password, authorities);
@@ -20,6 +22,12 @@ public class MemberDetails extends User {
 
   public String getEmail() {
     return super.getUsername();
+  }
+
+  public List<Role> getRole() {
+    return super.getAuthorities().stream()
+        .map(r -> Role.valueOf(r.getAuthority()))
+        .collect(Collectors.toList());
   }
 
   public static List<SimpleGrantedAuthority> parseAuthorities(Role role) {

--- a/app/src/main/java/com/hotelJava/security/config/SecurityConfig.java
+++ b/app/src/main/java/com/hotelJava/security/config/SecurityConfig.java
@@ -89,7 +89,6 @@ public class SecurityConfig {
         .build();
   }
 
-  @Bean
   public LoginAuthenticationFilter loginFilter(AuthenticationManager authenticationManager) {
     LoginAuthenticationFilter filter = new LoginAuthenticationFilter(LOGIN_URL);
     filter.setAuthenticationManager(authenticationManager);
@@ -97,7 +96,6 @@ public class SecurityConfig {
     return filter;
   }
 
-  @Bean
   public JwtAuthenticationFilter jwtFilter(AuthenticationManager authenticationManager) {
     FilterSkipMatcher matcher =
         new FilterSkipMatcher(
@@ -107,7 +105,6 @@ public class SecurityConfig {
     return filter;
   }
 
-  @Bean
   public CharacterEncodingFilter encodingFilter() {
     CharacterEncodingFilter encodingFilter = new CharacterEncodingFilter();
     encodingFilter.setEncoding("UTF-8");

--- a/app/src/main/java/com/hotelJava/security/filter/JwtAuthenticationFilter.java
+++ b/app/src/main/java/com/hotelJava/security/filter/JwtAuthenticationFilter.java
@@ -53,7 +53,14 @@ public class JwtAuthenticationFilter extends AbstractAuthenticationProcessingFil
     SecurityContext context = SecurityContextHolder.createEmptyContext();
     context.setAuthentication(authResult);
     SecurityContextHolder.setContext(context);
-
     chain.doFilter(request, response);
+  }
+
+  @Override
+  protected void unsuccessfulAuthentication(
+      HttpServletRequest request, HttpServletResponse response, AuthenticationException failed)
+      throws ServletException, IOException {
+    SecurityContextHolder.clearContext();
+    super.getFailureHandler().onAuthenticationFailure(request, response, failed);
   }
 }

--- a/app/src/main/java/com/hotelJava/security/filter/LoginAuthenticationFilter.java
+++ b/app/src/main/java/com/hotelJava/security/filter/LoginAuthenticationFilter.java
@@ -7,15 +7,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 
 @Slf4j
 public class LoginAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
-
-  @Autowired private ObjectMapper objectMapper;
 
   public LoginAuthenticationFilter(String defaultUrl) {
     super(defaultUrl);
@@ -33,6 +30,6 @@ public class LoginAuthenticationFilter extends AbstractAuthenticationProcessingF
   }
 
   private LoginDto getLoginDto(HttpServletRequest request) throws IOException {
-    return objectMapper.readValue(request.getInputStream(), LoginDto.class);
+    return new ObjectMapper().readValue(request.getInputStream(), LoginDto.class);
   }
 }


### PR DESCRIPTION
1. SecurityConfig 수정: 필터를 Bean으로 등록하지 않게 변경
- Bean으로 등록된 필터는 FilterChain에 등록하지 않아도 WebFilter로 동작하므로

2. LoginAuthenticationFilter 수정: 더 이상 Bean이 아니므로 ObjectMapper를 주입받지 못함. 메서드 안에서 객체를 생성하도록 변경

3. JwtAuthenticationFilter 수정: 인증 실패시 컨텍스트를 비워주는 로직을 추가