### PR TITLE
Hotfix: 시큐리티 테스트코드 외부 협력체 Mocking

### DIFF
--- a/app/src/main/java/com/hotelJava/security/filter/LoginAuthenticationFilter.java
+++ b/app/src/main/java/com/hotelJava/security/filter/LoginAuthenticationFilter.java
@@ -1,6 +1,8 @@
 package com.hotelJava.security.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hotelJava.common.error.ErrorCode;
+import com.hotelJava.common.error.exception.BadRequestException;
 import com.hotelJava.security.dto.LoginDto;
 import com.hotelJava.security.token.LoginPreAuthenticationToken;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,8 +22,7 @@ public class LoginAuthenticationFilter extends AbstractAuthenticationProcessingF
 
   @Override
   public Authentication attemptAuthentication(
-      HttpServletRequest request, HttpServletResponse response)
-      throws AuthenticationException, IOException {
+      HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
     log.trace("login request received");
     LoginDto loginDto = getLoginDto(request);
     LoginPreAuthenticationToken preAuthToken = new LoginPreAuthenticationToken(loginDto);
@@ -29,7 +30,12 @@ public class LoginAuthenticationFilter extends AbstractAuthenticationProcessingF
     return getAuthenticationManager().authenticate(preAuthToken);
   }
 
-  private LoginDto getLoginDto(HttpServletRequest request) throws IOException {
-    return new ObjectMapper().readValue(request.getInputStream(), LoginDto.class);
+  private LoginDto getLoginDto(HttpServletRequest request) {
+    try {
+      return new ObjectMapper().readValue(request.getInputStream(), LoginDto.class);
+    } catch (IOException e) {
+      log.error("login dto read failed", e);
+      throw new BadRequestException(ErrorCode.BAD_REQUEST_ERROR);
+    }
   }
 }

--- a/app/src/test/java/com/hotelJava/security/filter/JwtAuthenticationFilterTest.java
+++ b/app/src/test/java/com/hotelJava/security/filter/JwtAuthenticationFilterTest.java
@@ -1,45 +1,56 @@
 package com.hotelJava.security.filter;
 
+import static org.mockito.Mockito.*;
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.*;
+
 import com.hotelJava.common.error.exception.BadRequestException;
-import com.hotelJava.member.MemberTestFixture;
-import com.hotelJava.member.domain.Member;
-import com.hotelJava.security.token.JwtPostAuthenticationToken;
-import com.hotelJava.security.util.impl.JwtPayload;
-import com.hotelJava.security.util.impl.JwtTokenFactory;
-import java.util.List;
+import com.hotelJava.security.token.JwtPreAuthenticationToken;
+import com.hotelJava.security.util.impl.HeaderTokenExtractor;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.authentication.AuthenticationManager;
 
 @SpringBootTest
 class JwtAuthenticationFilterTest {
 
-  @Autowired private JwtAuthenticationFilter jwtFilter;
-  @Autowired private JwtTokenFactory jwtTokenFactory;
+  private JwtAuthenticationFilter jwtFilter;
+  @Spy private AuthenticationManager authenticationManager;
+  @Spy private HeaderTokenExtractor extractor;
+
+  @BeforeEach
+  void setUp() {
+    FilterSkipMatcher matcher =
+        new FilterSkipMatcher(
+            "/api/**", antMatcher(HttpMethod.POST, "/api/members"), antMatcher("/login"));
+    jwtFilter = new JwtAuthenticationFilter(matcher, extractor);
+    jwtFilter.setAuthenticationManager(authenticationManager);
+  }
 
   @Test
-  @DisplayName("인증에 성공한다면 JwtPostAuthenticationToken 객체가 반환된다")
+  @DisplayName("HttpRequestHeader 안에 token 데이터가 있다면, AuthenticationManager.authenticate 메서드가 호출된다")
   void attemptAuthentication_Authentication_success() {
     // given
     MockHttpServletRequest request = new MockHttpServletRequest();
     MockHttpServletResponse response = new MockHttpServletResponse();
-    String token = getJwtToken(MemberTestFixture.getMember(), System.currentTimeMillis());
-    request.addHeader("Authorization", token);
+    doReturn("token").when(extractor).extract(nullable(String.class));
 
     // when
-    Authentication authentication = jwtFilter.attemptAuthentication(request, response);
+    jwtFilter.attemptAuthentication(request, response);
 
     // then
-    Assertions.assertThat(authentication).isInstanceOf(JwtPostAuthenticationToken.class);
+    Mockito.verify(authenticationManager).authenticate(any(JwtPreAuthenticationToken.class));
   }
 
   @Test
-  @DisplayName("인증에 실패한다면 BadRequestException 예외가 발생한다")
+  @DisplayName("HttpRequestHeader 안에 token 데이터가 없다면, BadRequestException 예외가 발생한다")
   void attemptAuthentication_Exception_failed() {
     // given
     MockHttpServletRequest request = new MockHttpServletRequest();
@@ -48,14 +59,5 @@ class JwtAuthenticationFilterTest {
     // when
     Assertions.assertThatThrownBy(() -> jwtFilter.attemptAuthentication(request, response))
         .isInstanceOf(BadRequestException.class);
-  }
-
-  private String getJwtToken(Member member, long currentTime) {
-    JwtPayload payload =
-        JwtPayload.builder()
-            .subject(member.getEmail())
-            .roles(List.of(member.getRole().name()))
-            .build();
-    return jwtTokenFactory.generate(payload, currentTime);
   }
 }

--- a/app/src/test/java/com/hotelJava/security/filter/LoginAuthenticationFilterTest.java
+++ b/app/src/test/java/com/hotelJava/security/filter/LoginAuthenticationFilterTest.java
@@ -1,64 +1,61 @@
 package com.hotelJava.security.filter;
 
+import static org.mockito.Mockito.*;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javafaker.Faker;
 import com.hotelJava.common.error.exception.BadRequestException;
-import com.hotelJava.member.MemberTestFixture;
-import com.hotelJava.member.dto.SignUpRequestDto;
-import com.hotelJava.member.service.MemberService;
 import com.hotelJava.security.dto.LoginDto;
-import com.hotelJava.security.token.LoginPostAuthenticationToken;
+import com.hotelJava.security.token.LoginPreAuthenticationToken;
 import java.io.IOException;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.mockito.Spy;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.authentication.AuthenticationManager;
 
 @SpringBootTest
 class LoginAuthenticationFilterTest {
 
+  private final Faker faker = Faker.instance();
   private final ObjectMapper objectMapper = new ObjectMapper();
-  @Autowired private LoginAuthenticationFilter loginFilter;
-  @Autowired private MemberService memberService;
+  private final LoginAuthenticationFilter loginFilter = new LoginAuthenticationFilter("/login");
+  @Spy private AuthenticationManager authenticationManager;
+
+  @BeforeEach
+  void setUp() {
+    loginFilter.setAuthenticationManager(authenticationManager);
+  }
 
   @Test
-  @DisplayName("인증에 성공한다면 Authentication 객체가 리턴된다")
+  @DisplayName("HttpRequestBody 안에 LoginDto 데이터가 있다면, AuthenticationManager.authenticate 메서드가 호출된다")
   void attemptAuthentication_Authentication_success() throws IOException {
     // given
     MockHttpServletRequest request = new MockHttpServletRequest();
     MockHttpServletResponse response = new MockHttpServletResponse();
-
-    SignUpRequestDto signUpDto = MemberTestFixture.getSignUpDto();
-    memberService.signUp(signUpDto);
+    String email = faker.internet().emailAddress();
+    String password = faker.internet().password();
+    request.setContent(objectMapper.writeValueAsBytes(new LoginDto(email, password)));
 
     // when
-    LoginDto dto = new LoginDto(signUpDto.getEmail(), signUpDto.getPassword());
-    request.setContent(objectMapper.writeValueAsBytes(dto));
-    Authentication authentication = loginFilter.attemptAuthentication(request, response);
+    loginFilter.attemptAuthentication(request, response);
 
     // then
-    Assertions.assertThat(authentication).isInstanceOf(LoginPostAuthenticationToken.class);
+    verify(authenticationManager).authenticate(any(LoginPreAuthenticationToken.class));
   }
 
   @Test
-  @DisplayName("인증에 실패한다면 BadRequestException 예외가 발생한다")
-  void attemptAuthentication_Exception_failed() throws IOException {
+  @DisplayName("Http 요청의 바디에 LoginDto 데이터가 없다면, BadRequestException 예외가 발생한다")
+  void attemptAuthentication_Exception_failed() {
     // given
     MockHttpServletRequest request = new MockHttpServletRequest();
     MockHttpServletResponse response = new MockHttpServletResponse();
 
-    String email = Faker.instance().internet().emailAddress();
-    String password = Faker.instance().internet().password();
-
-    // when
-    LoginDto dto = new LoginDto(email, password);
-    request.setContent(objectMapper.writeValueAsBytes(dto));
-
-    // then
+    // when, then
     Assertions.assertThatThrownBy(() -> loginFilter.attemptAuthentication(request, response))
         .isInstanceOf(BadRequestException.class);
   }

--- a/app/src/test/java/com/hotelJava/security/handler/LoginAuthenticationSuccessHandlerTest.java
+++ b/app/src/test/java/com/hotelJava/security/handler/LoginAuthenticationSuccessHandlerTest.java
@@ -1,14 +1,22 @@
 package com.hotelJava.security.handler;
 
-import com.hotelJava.member.MemberTestFixture;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.javafaker.Faker;
+import com.hotelJava.MemberTestFixture;
 import com.hotelJava.member.domain.Member;
 import com.hotelJava.security.MemberDetails;
+import com.hotelJava.security.dto.TokenDto;
 import com.hotelJava.security.token.LoginPostAuthenticationToken;
+import com.hotelJava.security.util.impl.JwtPayload;
+import com.hotelJava.security.util.impl.JwtTokenFactory;
+import java.io.IOException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
@@ -16,11 +24,14 @@ import org.springframework.security.core.Authentication;
 @SpringBootTest
 class LoginAuthenticationSuccessHandlerTest {
 
+  private final Faker faker = Faker.instance();
+  private final ObjectMapper objectMapper = new ObjectMapper();
   @Autowired private LoginAuthenticationSuccessHandler successHandler;
+  @SpyBean JwtTokenFactory jwtTokenFactory;
 
   @Test
-  @DisplayName("로그인에 성공하면 응답 메시지의 Authorization 헤더에 토큰값을 남긴다")
-  void onAuthenticationSuccess() {
+  @DisplayName("로그인에 성공하면 응답 메시지에 토큰값을 남긴다")
+  void onAuthenticationSuccess() throws IOException {
     // given
     Member member = MemberTestFixture.getMember();
     MemberDetails memberDetails = new MemberDetails(member);
@@ -29,10 +40,17 @@ class LoginAuthenticationSuccessHandlerTest {
     MockHttpServletResponse response = new MockHttpServletResponse();
     Authentication authentication = new LoginPostAuthenticationToken(memberDetails);
 
+    String token = faker.letterify("?????");
+
+    Mockito.doReturn(token)
+        .when(jwtTokenFactory)
+        .generate(Mockito.any(JwtPayload.class), Mockito.anyLong());
+
     // when
     successHandler.onAuthenticationSuccess(request, response, authentication);
 
     // then
-    Assertions.assertThat(response.getHeader("Authorization")).isNotNull();
+    Assertions.assertThat(objectMapper.readValue(response.getContentAsByteArray(), TokenDto.class))
+        .isEqualTo(new TokenDto(token));
   }
 }

--- a/app/src/test/java/com/hotelJava/security/provider/JwtAuthenticationProviderTest.java
+++ b/app/src/test/java/com/hotelJava/security/provider/JwtAuthenticationProviderTest.java
@@ -1,0 +1,38 @@
+package com.hotelJava.security.provider;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.github.javafaker.Faker;
+import com.hotelJava.MemberTestFixture;
+import com.hotelJava.security.MemberDetails;
+import com.hotelJava.security.token.JwtPostAuthenticationToken;
+import com.hotelJava.security.token.JwtPreAuthenticationToken;
+import com.hotelJava.security.util.impl.JwtTokenDecoder;
+import org.junit.jupiter.api.DisplayName;import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+@SpringBootTest
+class JwtAuthenticationProviderTest {
+
+  private final Faker faker = Faker.instance();
+
+  @Autowired private JwtAuthenticationProvider provider;
+  @SpyBean private JwtTokenDecoder decoder;
+
+  @Test
+  @DisplayName("token 값을 갖고 있는 JwtPreAuthenticationToken 에 대해 인증을 수행하면 JwtPostAuthenticationToken 이 생성된다")
+  void authenticate() {
+    // given
+    String token = faker.letterify("????");
+    JwtPreAuthenticationToken preAuthentication = new JwtPreAuthenticationToken(token);
+    MemberDetails loginMemberDetails = new MemberDetails(MemberTestFixture.getMember());
+    doReturn(loginMemberDetails).when(decoder).decode(anyString());
+
+    // when
+    assertThat(provider.authenticate(preAuthentication))
+        .isEqualTo(new JwtPostAuthenticationToken(loginMemberDetails));
+  }
+}

--- a/app/src/test/java/com/hotelJava/security/provider/MemberDetailsAuthenticationProviderTest.java
+++ b/app/src/test/java/com/hotelJava/security/provider/MemberDetailsAuthenticationProviderTest.java
@@ -1,0 +1,98 @@
+package com.hotelJava.security.provider;
+
+import com.hotelJava.MemberTestFixture;
+import com.hotelJava.common.error.exception.BadRequestException;
+import com.hotelJava.common.error.exception.InternalServerException;
+import com.hotelJava.member.domain.Member;
+import com.hotelJava.security.MemberDetails;
+import com.hotelJava.security.MemberDetailsService;
+import com.hotelJava.security.dto.LoginDto;
+import com.hotelJava.security.token.LoginPostAuthenticationToken;
+import com.hotelJava.security.token.LoginPreAuthenticationToken;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@SpringBootTest
+class MemberDetailsAuthenticationProviderTest {
+
+  @Autowired private MemberDetailsAuthenticationProvider provider;
+  @SpyBean private MemberDetailsService memberDetailsService;
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  @Test
+  @DisplayName("올바른 로그인요청 LoginDto 가 주어졌을 때, 인증작업은 LoginPostAuthenticationToken 을 발행한다")
+  void authenticate_success() {
+    // given
+    Member member = MemberTestFixture.getMember();
+    String originPassword = member.getPassword();
+    String encodedPassword = passwordEncoder.encode(originPassword);
+    member.changePassword(encodedPassword);
+
+    MemberDetails loginMemberDetails = new MemberDetails(member);
+    LoginPreAuthenticationToken preAuthentication =
+        new LoginPreAuthenticationToken(new LoginDto(member.getEmail(), originPassword));
+
+    Mockito.doReturn(loginMemberDetails)
+        .when(memberDetailsService)
+        .loadUserByUsername(Mockito.anyString());
+
+    // when
+    Authentication postAuthentication = provider.authenticate(preAuthentication);
+
+    // then
+    Assertions.assertThat(postAuthentication)
+        .isEqualTo(new LoginPostAuthenticationToken(loginMemberDetails));
+  }
+
+  @Test
+  @DisplayName("탈퇴한 회원에 대한 로그인 요청 LoginDto 가 주어졌을 때, 인증작업은 BadRequestException 을 발생시킨다")
+  void authenticate_deletedAccount_BadRequestException() {
+    // given
+    Member member = MemberTestFixture.getMember();
+    member.deleteAccount();
+    MemberDetails loginMemberDetails = new MemberDetails(member);
+    LoginPreAuthenticationToken preAuthentication =
+        new LoginPreAuthenticationToken(new LoginDto(member.getEmail(), member.getPassword()));
+
+    Mockito.doReturn(loginMemberDetails)
+        .when(memberDetailsService)
+        .loadUserByUsername(Mockito.anyString());
+
+    // when, then
+    Assertions.assertThatThrownBy(() -> provider.authenticate(preAuthentication))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  @DisplayName("비밀번호가 틀린 로그인 요청 LoginDto 가 주어졌을 때, 인증작업은 BadRequestException 을 발생시킨다")
+  void authenticate_wrongPassword_BadRequestException() {
+    // given
+    Member member = MemberTestFixture.getMember();
+    MemberDetails loginMemberDetails = new MemberDetails(member);
+    LoginPreAuthenticationToken preAuthentication =
+        new LoginPreAuthenticationToken(
+            new LoginDto(member.getEmail(), member.getPassword() + "mistake"));
+
+    Mockito.doReturn(loginMemberDetails)
+        .when(memberDetailsService)
+        .loadUserByUsername(Mockito.anyString());
+
+    // when, then
+    Assertions.assertThatThrownBy(() -> provider.authenticate(preAuthentication))
+        .isInstanceOf(BadRequestException.class);
+  }
+
+  @Test
+  @DisplayName("PreAuthentication 이 null 일 때, 인증작업은 InternalRequestException 을 발생시킨다")
+  void authenticate_PreAuthentication_null_InternalException() {
+    Assertions.assertThatThrownBy(() -> provider.authenticate(null))
+        .isInstanceOf(InternalServerException.class);
+  }
+}


### PR DESCRIPTION
# 🎯 주요작업
1. 시큐리티 관련 클래스 (`JwtAuthenticationFilter`, `LoginAuthenticationFilter`, `LoginAuthenticationSuccessHandler`)의 외부 협력체를 Mocking
2. JwtAuthenticationProvider, MemberDetailsAuthenticationProvider 테스트코드 추가
3. LoginAuthenticationFilter 에서 RequestBody의 LoginDto를 읽는 동작을 실패하였을 때, BadRequestException 발생하도록 구현

# ❓궁금한 점
테스트 대상의 외부 협력체들을 Mocking 하도록 수정하였습니다. 처음 시도해본 것이라 이 방법이 맞는지 궁금합니다.