### PR TITLE
[#25] 객실 예약 도메인 구현

### DIFF
--- a/app/src/main/java/com/hotelJava/accommodation/domain/Accommodation.java
+++ b/app/src/main/java/com/hotelJava/accommodation/domain/Accommodation.java
@@ -3,6 +3,7 @@ package com.hotelJava.accommodation.domain;
 import com.hotelJava.common.embeddable.Address;
 import com.hotelJava.common.util.BaseTimeEntity;
 import com.hotelJava.picture.domain.Picture;
+import com.hotelJava.picture.domain.PictureType;
 import com.hotelJava.reservation.domain.ReservationStatus;
 import com.hotelJava.room.domain.Room;
 import jakarta.persistence.CascadeType;
@@ -84,11 +85,12 @@ public class Accommodation extends BaseTimeEntity {
   // == 연관관계 편의 메소드 ==//
   public void setPicture(Picture picture) {
     this.picture = picture;
+    picture.setPictureType(PictureType.ACCOMMODATION);
     picture.setAccommodation(this);
   }
 
   public void createAccommodation(List<Room> rooms, Picture accommodationPicture) {
-    this.picture = accommodationPicture;
+    setPicture(accommodationPicture);
     this.rooms.addAll(rooms);
     rooms.forEach(room -> room.setAccommodation(this));
   }

--- a/app/src/main/java/com/hotelJava/common/embeddable/CheckDate.java
+++ b/app/src/main/java/com/hotelJava/common/embeddable/CheckDate.java
@@ -21,4 +21,8 @@ public class CheckDate {
 
   @DateTimeFormat(pattern = "yyyy-MM-dd")
   private LocalDate checkOutDate;
+
+  public boolean matches(LocalDate date) {
+    return date.isEqual(checkInDate) || (date.isAfter(checkInDate) && date.isBefore(checkOutDate));
+  }
 }

--- a/app/src/main/java/com/hotelJava/common/error/ErrorCode.java
+++ b/app/src/main/java/com/hotelJava/common/error/ErrorCode.java
@@ -25,11 +25,18 @@ public enum ErrorCode {
   DUPLICATED_NAME_FOUND(409, "숙소명이 이미 존재합니다."),
   NO_MINIMUM_PRICE_FOUND(500, "숙소의 최소 가격을 찾을 수 없습니다."),
 
+  // 예약 관련 에러
+  OUT_OF_STOCK(400, "재고 수량이 부족합니다"),
+  OVER_MAX_OCCUPANCY(400, "객실 최대 인원을 초과하였습니다"),
+
+  // 결제 관련 에러
+  PAYMENT_FAIL(400, "결제 오류"),
+
   // 클라이언트 에러
-  BAD_REQUEST_ERROR(400, "요청값이 잘못되었습니다."),
-  
+  BAD_REQUEST_ERROR(400, "요청값이 잘못되었습니다"),
+
   // 서버 에러
-  INTERNAL_SERVER_ERROR(500, "요청을 정상 처리하지 못하였습니다.");
+  INTERNAL_SERVER_ERROR(500, "요청을 정상 처리하지 못하였습니다");
 
   private final int code;
   private final String message;

--- a/app/src/main/java/com/hotelJava/inventory/Inventory.java
+++ b/app/src/main/java/com/hotelJava/inventory/Inventory.java
@@ -1,18 +1,26 @@
 package com.hotelJava.inventory;
 
+import com.hotelJava.common.embeddable.CheckDate;
+import com.hotelJava.common.error.ErrorCode;
+import com.hotelJava.common.error.exception.BadRequestException;
 import com.hotelJava.common.util.BaseTimeEntity;
+import com.hotelJava.room.domain.Room;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Entity
 @Getter
 @Setter
@@ -25,11 +33,38 @@ public class Inventory extends BaseTimeEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  private Long accommodationId;
+  @ManyToOne
+  @JoinColumn(name = "room_id")
+  private Room room;
 
-  private Long roomId;
-  
   private LocalDate date;
-  
+
   private long quantity;
+
+  public Inventory(LocalDate date, long quantity) {
+    this.date = date;
+    this.quantity = quantity;
+  }
+
+  public boolean isEnoughQuantity() {
+    if (quantity <= 0) {
+      log.error("quantity at {} is 0", date);
+      return false;
+    }
+    return true;
+  }
+
+  public void validate() {
+    if (!isEnoughQuantity()) {
+      throw new BadRequestException(ErrorCode.OUT_OF_STOCK);
+    }
+  }
+
+  public Inventory reduceQuantity(CheckDate checkDate) {
+    if (checkDate.matches(date)) {
+      validate();
+      return new Inventory(date, quantity - 1);
+    }
+    return this;
+  }
 }

--- a/app/src/main/java/com/hotelJava/inventory/repository/InventoryRepository.java
+++ b/app/src/main/java/com/hotelJava/inventory/repository/InventoryRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;import java.util.List;
 @Repository
 public interface InventoryRepository extends JpaRepository<Inventory, Long> {
 
-  List<Inventory> findByAccommodationIdAndRoomId(Long accommodationId, Long roomId);
+  List<Inventory> findByRoomId(Long roomId);
 }

--- a/app/src/main/java/com/hotelJava/payment/domain/Payment.java
+++ b/app/src/main/java/com/hotelJava/payment/domain/Payment.java
@@ -1,0 +1,43 @@
+package com.hotelJava.payment.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder.Default;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Payment {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private int amount;
+  private PaymentType paymentType;
+  private LocalDateTime paymentDate;
+
+//  @Default private PaymentStatus status = PaymentStatus.WAITING;
+
+  public Payment(int amount) {
+    this.amount = amount;
+  }
+
+  //  public void changeStatus(PaymentStatus status) {
+  //    this.status = status;
+  //  }
+
+  public boolean isPaymentSuccess() {
+    // TODO: 포트원 API 로부터 정상 결제됐는지 확인
+    // if (정상처리) this.status = PaymentStatus.COMPLETE;
+    //    return status == PaymentStatus.COMPLETE;
+    return true;
+  }
+}

--- a/app/src/main/java/com/hotelJava/payment/domain/PaymentStatus.java
+++ b/app/src/main/java/com/hotelJava/payment/domain/PaymentStatus.java
@@ -1,0 +1,14 @@
+package com.hotelJava.payment.domain;
+
+public enum PaymentStatus {
+  WAITING("결제대기"),
+  COMPLETE("결제완료"),
+  CANCEL("결제취소"),
+  ERROR("결제오류");
+
+  private final String label;
+
+  PaymentStatus(String label) {
+    this.label = label;
+  }
+}

--- a/app/src/main/java/com/hotelJava/reservation/domain/GuestInfo.java
+++ b/app/src/main/java/com/hotelJava/reservation/domain/GuestInfo.java
@@ -1,0 +1,12 @@
+package com.hotelJava.reservation.domain;
+
+import com.hotelJava.common.embeddable.CheckDate;
+import com.hotelJava.member.domain.Member;
+
+public interface GuestInfo {
+  Member getMember();
+
+  int getNumberOfGuests();
+
+  CheckDate getCheckDate();
+}

--- a/app/src/main/java/com/hotelJava/reservation/domain/Reservation.java
+++ b/app/src/main/java/com/hotelJava/reservation/domain/Reservation.java
@@ -1,58 +1,46 @@
 package com.hotelJava.reservation.domain;
 
 import com.hotelJava.common.embeddable.CheckDate;
+import com.hotelJava.common.error.ErrorCode;
+import com.hotelJava.common.error.exception.BadRequestException;
 import com.hotelJava.common.util.BaseTimeEntity;
 import com.hotelJava.member.domain.Member;
-import com.hotelJava.payment.domain.PaymentType;
+import com.hotelJava.payment.domain.Payment;
 import com.hotelJava.room.domain.Room;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.NoArgsConstructor;import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Entity
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Reservation extends BaseTimeEntity {
+public class Reservation extends BaseTimeEntity implements GuestInfo {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  private String name;
-
   private String reservationNo;
 
-  private String accommodationName;
-
-  private String roomName;
+  @Builder.Default
+  @Enumerated(EnumType.STRING)
+  private ReservationStatus status = ReservationStatus.PAYMENT_PENDING;
 
   @Embedded private CheckDate checkDate;
 
   private int numberOfGuests;
 
-  @Enumerated(EnumType.STRING)
-  private PaymentType paymentType;
-
-  private String phoneNumber;
-
-  @Enumerated(EnumType.STRING)
-  private ReservationStatus status;
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "payment_id")
+  private Payment payment;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id")
@@ -61,4 +49,32 @@ public class Reservation extends BaseTimeEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "room_id")
   private Room room;
+
+  public Reservation(GuestInfo info) {
+    this.member = info.getMember();
+    this.checkDate = info.getCheckDate();
+    this.numberOfGuests = info.getNumberOfGuests();
+    this.payment = new Payment(room.calcPrice());
+  }
+
+  public Reservation confirm() {
+    validateReservation();
+    if (!payment.isPaymentSuccess()) {
+      throw new BadRequestException(ErrorCode.PAYMENT_FAIL);
+    }
+    room.reduceStock(checkDate);
+    // TODO: 결제승인
+    status = ReservationStatus.RESERVATION_COMPLETED;
+    // payment.approve();
+    return this;
+  }
+
+  public void validateReservation() {
+    if (!room.isAvailableReservation(numberOfGuests, checkDate)) {
+      // TODO: 결제승인거절
+      // payment.decline();
+      log.info("payment declined");
+      throw new BadRequestException(ErrorCode.PAYMENT_FAIL);
+    }
+  }
 }

--- a/app/src/main/java/com/hotelJava/reservation/domain/ReservationStatus.java
+++ b/app/src/main/java/com/hotelJava/reservation/domain/ReservationStatus.java
@@ -10,7 +10,8 @@ public enum ReservationStatus {
     RESERVATION_AVAILABLE("예약가능"),
     RESERVATION_COMPLETED("예약완료"),
     RESERVATION_CANCEL("예약취소"),
-    SALES_COMPLETED("판매완료");
+    SALES_COMPLETED("판매완료"),
+    PAYMENT_PENDING("결제대기");
 
     private final String label;
 }

--- a/app/src/main/java/com/hotelJava/room/domain/Room.java
+++ b/app/src/main/java/com/hotelJava/room/domain/Room.java
@@ -1,12 +1,13 @@
 package com.hotelJava.room.domain;
 
 import com.hotelJava.accommodation.domain.Accommodation;
-import com.hotelJava.common.embeddable.CheckTime;
+import com.hotelJava.common.embeddable.CheckDate;
 import com.hotelJava.common.util.BaseTimeEntity;
+import com.hotelJava.inventory.Inventory;
 import com.hotelJava.picture.domain.Picture;
 import com.hotelJava.reservation.domain.Reservation;
+import com.hotelJava.reservation.domain.GuestInfo;
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -17,13 +18,16 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Entity
 @Getter
 @Setter
@@ -46,8 +50,6 @@ public class Room extends BaseTimeEntity {
   @JoinColumn(name = "accommodation_id") // accommodation_id 외래 키로 연관관계를 맺는다.
   private Accommodation accommodation;
 
-  @Embedded private CheckTime checkTime;
-
   @OneToMany(mappedBy = "room", cascade = CascadeType.ALL)
   @Builder.Default
   private List<Picture> pictures = new ArrayList<>();
@@ -58,21 +60,55 @@ public class Room extends BaseTimeEntity {
 
   @OneToMany(mappedBy = "room", cascade = CascadeType.ALL)
   @Builder.Default
-  private List<RoomAvailability> roomAvailabilities = new ArrayList<>();
+  private List<Inventory> inventories = new ArrayList<>();
+
+  public Reservation reserve(GuestInfo info) {
+    Reservation reservation = new Reservation(info);
+    reservations.add(reservation);
+    return reservation;
+  }
+
+  public List<Inventory> reduceStock(CheckDate checkDate) {
+    return inventories.stream()
+        .map(item -> item.reduceQuantity(checkDate))
+        .collect(Collectors.toList());
+  }
+
+  public boolean isAvailableReservation(int numberOfGuests, CheckDate checkDate) {
+    if (!isLowerMaxOccupancy(numberOfGuests)) {
+      log.info("numberOfGuests({}) is over maxOccupancy({})", numberOfGuests, maxOccupancy);
+      return false;
+    }
+    return isStockEnough(checkDate);
+  }
+
+  public boolean isStockEnough(CheckDate checkDate) {
+    return inventories.stream()
+        .filter(i -> checkDate.matches(i.getDate()))
+        .allMatch(Inventory::isEnoughQuantity);
+  }
+
+  public boolean isLowerMaxOccupancy(int guestNumber) {
+    return guestNumber <= maxOccupancy;
+  }
+
+  public int calcPrice() {
+    return price;
+  }
 
   // == 연관관계 편의 메소드 ==//
   public void addPicture(Picture picture) {
-    this.pictures.add(picture);
+    pictures.add(picture);
     picture.setRoom(this);
   }
 
   public void addReservation(Reservation reservation) {
-    this.reservations.add(reservation);
+    reservations.add(reservation);
     reservation.setRoom(this);
   }
 
-  public void addRoomAvailability(RoomAvailability roomAvailability) {
-    this.roomAvailabilities.add(roomAvailability);
-    roomAvailability.setRoom(this);
+  public void addInventory(Inventory inventory) {
+    inventories.add(inventory);
+    inventory.setRoom(this);
   }
 }

--- a/app/src/test/java/com/hotelJava/inventory/InventoryTest.java
+++ b/app/src/test/java/com/hotelJava/inventory/InventoryTest.java
@@ -1,0 +1,70 @@
+package com.hotelJava.inventory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hotelJava.TestFixture;
+import com.hotelJava.common.embeddable.CheckDate;
+import com.hotelJava.common.error.exception.BadRequestException;
+import java.time.LocalDate;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class InventoryTest {
+
+  @Test
+  @DisplayName("재고가 1보다 많다면 true 를 반환한다")
+  void 재고검사() {
+    // given
+    Inventory inventory = TestFixture.getInventory(TestFixture.getRoom(1), LocalDate.now(), 10);
+
+    // when
+    boolean enoughQuantity = inventory.isEnoughQuantity();
+
+    // then
+    assertThat(enoughQuantity).isTrue();
+  }
+
+  @Test
+  @DisplayName("재고가 1보다 적다면 false 를 반환한다")
+  void 재고검사_재고부족() {
+    // given
+    Inventory inventory = TestFixture.getInventory(TestFixture.getRoom(1), LocalDate.now(), 10);
+
+    // when
+    boolean enoughQuantity = inventory.isEnoughQuantity();
+
+    // then
+    assertThat(enoughQuantity).isTrue();
+  }
+
+  @Test
+  @DisplayName("숙박 기간에 해당하는 객실상품이고 재고가 1보다 크다면 재고를 1 감소시킨다")
+  void 재고감소() {
+    // given
+    Inventory inventory = TestFixture.getInventory(TestFixture.getRoom(1), LocalDate.now(), 10);
+    LocalDate checkin = LocalDate.now();
+    LocalDate checkout = checkin.plusDays(1);
+    CheckDate checkDate = new CheckDate(checkin, checkout);
+
+    // when
+    long expect = inventory.getQuantity() - 1;
+
+    // then
+    assertThat(inventory.reduceQuantity(checkDate).getQuantity()).isEqualTo(expect);
+  }
+
+  @Test
+  @DisplayName("체크인 ~ 체크아웃 기간의 객실재고 중 1보다 작은 날이 하루라도 존재하면 예외가 발생한다")
+  void 재고감소_예외발생_재고부족() {
+    // given
+    Inventory inventory = TestFixture.getInventory(TestFixture.getRoom(1), LocalDate.now(), 0);
+    LocalDate checkin = LocalDate.now();
+    LocalDate checkout = checkin.plusDays(1);
+    CheckDate checkDate = new CheckDate(checkin, checkout);
+
+    // when, then
+    Assertions.assertThatThrownBy(() -> inventory.reduceQuantity(checkDate))
+        .isInstanceOf(BadRequestException.class);
+  }
+}


### PR DESCRIPTION
# 🎯 주요 작업 내용
## Inventory 클래스: 객실의 날짜별 재고 관리 역할

- 재고량이 남아있는지 확인하는 기능
```java
public boolean isEnoughQuantity()
```

- 재고를 감소하는 기능
```java
public Inventory reduceQuantity(CheckDate checkDate)
```
❓ 질문) 재고를 감소시킬 때, `Inventory.quantity`의 상태를 바꾸지 않고 `Inventory.quantity-1`의 상태를 갖는 Inventory 객체를 새롭게 생성하였습니다. 순수함수 형태를 띄게 해봤는데, 이 방식의 단점이 있다면 무엇일지 궁금합니다. 제가 생각하기엔 객체를 쓸데없이 만들어서 메모리 낭비가 있을 것 같다는 것입니다.

<br/>
<br/>

## Room 클래스: 예약 기능

- 주어진 기간의 객실재고 감소 기능
```java
  public List<Inventory> reduceStock(CheckDate checkDate);
```
마찬가지로 순수함수 형태로 구현하려고 시도해봤습니다.

- 그외 유효성 검사 기능
```java
public boolean isAvailableReservation(int numberOfGuests, CheckDate checkDate)
public boolean isStockEnough(CheckDate checkDate)
public boolean isLowerMaxOccupancy(int guestNumber)
```

- 예약 객체 생성 기능
 ```java
public Reservation reserve(GuestInfo info);
```
❓ 질문) 예약 객체 생성에 필요한 스펙을 `GuestInfo` 인터페이스로 정의하였습니다. 그리고 Presentation Layer에서 사용자의 예약요청에 대한 정보를 `ReservationRequestDto`로 정의하고 `GuestInfo` 인터페이스 구현할 예정입니다. 구현할 기능에 어떤 정보가 필요한지 스펙으로 정의해두는 연습을 해봤습니다. 이런식으로 모든 도메인들은 RequestDto 같은 구현체가 아니라 스펙에 의존하게 하면 되는걸까요?

<br/>
<br/>

## Payment 클래스: 결제 담당
```java
  public boolean isPaymentSuccess(결제처리정보) {
    포트원 API 로부터 정상 결제됐는지 확인
    if (정상처리) {
        this.status = PaymentStatus.COMPLETE;
    }
    return status == PaymentStatus.COMPLETE;
}
```
❓ 질문) Payment 도메인은 유저의 결제가 정상처리됐는지 확인하는 기능을 갖고 있습니다. 위 코드는 제가 생각한 로직입니다. 
 isPaymentSuccess() 메서드는 포트원이 전송할 결제 처리 결과 (`PortOnePayResult`)에 의존하게 됩니다. 제 생각엔 isPaymentSuccess() 메서드가 직접적으로`PortOnePayResult`에 의존하게 두는 것보다, 중간 추상화 레이어를 만들고 그것에 의존하는 것이 좋겠다고 생각했습니다. 그리고 그 구현체에는 `PortOnePayResult`에 대한 정보를 담아주면 될 것 같습니다. 이렇게 생각한 이유는 **도메인에 외부 API의 침범을 막기** 위해서 입니다. 제 생각에 대해 좀 더 생각해볼만한 점이나 멘토님의 추가 의견이 궁금합니다.

❓ 질문) 도메인들의 순환 참조 문제, 패키지 간 양방향 참조가 일어나는 문제 등에 대해서도 어떤 문제점이 있고 어떻게 해결하는지 알고 싶습니다.

</br>
</br>

# 💪  시도한 노력
- 도메인 패턴의 개발 방식을 시도
- 스펙에 의존하고, 스펙을 노출하려고 했음
- 클래스,패키지 간 의존성에 대해 고민